### PR TITLE
Add data organise module

### DIFF
--- a/scripts/organise_external_data.py
+++ b/scripts/organise_external_data.py
@@ -1,0 +1,33 @@
+"""Script to organise both the TREC Public Spam Corpus and SpamAssassin external datasets.
+
+Before running:
+    1. Ensure you have downloaded and unzipped the TREC dataset into:
+       `data/raw_external/trec`
+       ensuring that a `full/index` file and `data/` folder exists under that path.
+
+    2. Ensure you have downloaded and unzipped the SpamAssassin public corpus into:
+       `data/raw_external/spamassassin`
+       with subfolders whose names include “ham” and “spam”.
+
+    3. Install dev dependencies via Poetry (if not already done):
+       > poetry install --with dev
+
+Usage:
+    > python organise_datasets.py
+
+This will create (if missing) the following folders and move the .eml files into them:
+    - `data/raw/trec_ham`
+    - `data/raw/trec_spam`
+    - `data/raw/spamassassin_ham`
+    - `data/raw/spamassassin_spam`
+"""
+
+from __future__ import annotations
+
+from email_spam_filter.common import logger
+from email_spam_filter.data.organise import DATASET_MODULES
+
+if __name__ == "__main__":
+    logger()
+    for organise_dataset in DATASET_MODULES.values():
+        organise_dataset()

--- a/src/email_spam_filter/common/__init__.py
+++ b/src/email_spam_filter/common/__init__.py
@@ -1,6 +1,7 @@
 """Common utilities and shared data structures for the email-spam-filter project.
 
 Modules:
+    containers: Shared dataclass definitions for structured data exchange across modules.
     constants: Global constants and user configurations values.
     functions: Generic utility functions.
     paths: Paths to important project resources.

--- a/src/email_spam_filter/common/containers.py
+++ b/src/email_spam_filter/common/containers.py
@@ -22,7 +22,7 @@ class DatasetPaths:
         labels: Path to the .json labels file.
     """
 
-    raw_external: pathlib.Path | None
+    external: pathlib.Path | None
     raw_ham: pathlib.Path | None
     raw_spam: pathlib.Path | None
     raw_inbox: pathlib.Path | None

--- a/src/email_spam_filter/common/containers.py
+++ b/src/email_spam_filter/common/containers.py
@@ -1,0 +1,30 @@
+"""Shared dataclass definitions for structured data exchange across modules."""
+
+from __future__ import annotations
+
+import dataclasses
+import typing
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+
+@dataclasses.dataclass(frozen=True)
+class DatasetPaths:
+    """Holds all the Path objects for a given dataset.
+
+    Attributes:
+        external: Path to the external raw data download folder.
+        raw_ham: Path to the raw folder where ham .eml files are stored.
+        raw_spam: Path to the raw folder where spam .eml files are stored.
+        raw_inbox: Path to the raw folder where inbox .eml files are stored.
+        processed: Path to the processed Parquet database.
+        labels: Path to the .json labels file.
+    """
+
+    raw_external: pathlib.Path | None
+    raw_ham: pathlib.Path | None
+    raw_spam: pathlib.Path | None
+    raw_inbox: pathlib.Path | None
+    processed: pathlib.Path | None
+    labels: pathlib.Path | None

--- a/src/email_spam_filter/common/paths.py
+++ b/src/email_spam_filter/common/paths.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from email_spam_filter.common.containers import DatasetPaths
+
 BASE_DIR = Path(__file__).resolve().parents[3]
 """Base directory of the project."""
 
@@ -13,5 +15,34 @@ CONFIG_PATH = BASE_DIR / "user_config.yml"
 DATA_DIR = BASE_DIR / "data"
 """Path to the data folder."""
 
+LABELS_DIR = DATA_DIR / "labels"
+"""Path to the labels data folder."""
+
+PROCESSED_DIR = DATA_DIR / "processed"
+"""Path to the processed data folder."""
+
 RAW_DIR = DATA_DIR / "raw"
 """Path to the raw data folder."""
+
+RAW_EXTERNAL_DIR = DATA_DIR / "raw_external"
+"""Path to the raw external data folder. (e.g. TREC, SpamAssassin etc.)"""
+
+TREC_PATHS: DatasetPaths = DatasetPaths(
+    external=RAW_EXTERNAL_DIR / "trec",
+    raw_ham=RAW_DIR / "trec_ham",
+    raw_spam=RAW_DIR / "trec_spam",
+    raw_inbox=None,
+    processed=None,
+    labels=None,
+)
+"""Paths for the [TREC Public Spam Corpus dataset](https://plg.uwaterloo.ca/cgi-bin/cgiwrap/gvcormac/foo)."""
+
+SPAM_ASSASSIN_PATHS = DatasetPaths(
+    external=RAW_EXTERNAL_DIR / "spamassassin",
+    raw_ham=RAW_DIR / "spamassassin_ham",
+    raw_spam=RAW_DIR / "spamassassin_spam",
+    raw_inbox=None,
+    processed=None,
+    labels=None,
+)
+"""Paths for the [SpamAssassin Public Spam Corpus dataset](https://spamassassin.apache.org/old/publiccorpus/)."""

--- a/src/email_spam_filter/data/__init__.py
+++ b/src/email_spam_filter/data/__init__.py
@@ -2,12 +2,14 @@
 
 Modules:
     collection: Source-specific data collection utilities for acquiring external datasets.
+    organise: Source-specific pre-processing utilities for external datasets.
 """
 
 from __future__ import annotations
 
-__all__ = ("collection",)
+__all__ = ("collection", "organise")
 
 from email_spam_filter.data import (
     collection,
+    organise,
 )

--- a/src/email_spam_filter/data/organise/__init__.py
+++ b/src/email_spam_filter/data/organise/__init__.py
@@ -1,0 +1,21 @@
+"""Source-specific pre-processing utilities for external datasets.
+
+Modules:
+    spamassassin: Pre-processing utilities for the SpamAssassin dataset.
+    trec: Pre-processing utilities for the TREC Public Spam Corpus.
+"""
+
+from __future__ import annotations
+
+__all__ = (
+    "DATASET_MODULES",
+    "spamassassin",
+    "trec",
+)
+
+from email_spam_filter.data.organise import spamassassin, trec
+
+DATASET_MODULES = {
+    "TREC": trec.organise_trec_data,
+    "SpamAssassin": spamassassin.organise_spamassassin_data,
+}

--- a/src/email_spam_filter/data/organise/spamassassin/__init__.py
+++ b/src/email_spam_filter/data/organise/spamassassin/__init__.py
@@ -1,0 +1,13 @@
+"""Pre-processing utilities for the SpamAssassin dataset.
+
+Modules:
+    functions: Functions for loading and standardising the SpamAssassin dataset.
+"""
+
+from __future__ import annotations
+
+__all__ = ("organise_spamassassin_data",)
+
+from email_spam_filter.data.organise.spamassassin.functions import (
+    organise_spamassassin_data,
+)

--- a/src/email_spam_filter/data/organise/spamassassin/functions.py
+++ b/src/email_spam_filter/data/organise/spamassassin/functions.py
@@ -15,9 +15,9 @@ logger = logging.getLogger(__name__)
 
 
 def organise_spamassassin_data(
-    external_path: pathlib.Path = paths.SPAM_ASSASSIN_PATHS.external,
-    raw_ham_path: pathlib.Path = paths.SPAM_ASSASSIN_PATHS.raw_ham,
-    raw_spam_path: pathlib.Path = paths.SPAM_ASSASSIN_PATHS.raw_spam,
+    external_path: pathlib.Path | None = paths.SPAM_ASSASSIN_PATHS.external,
+    raw_ham_path: pathlib.Path | None = paths.SPAM_ASSASSIN_PATHS.raw_ham,
+    raw_spam_path: pathlib.Path | None = paths.SPAM_ASSASSIN_PATHS.raw_spam,
 ) -> None:
     """Reads the SpamAssassin external folders and copies each file into a ham or spam folder.
 
@@ -29,6 +29,10 @@ def organise_spamassassin_data(
         raw_spam_path: Path to the folder where the spam .eml files will be stored.
             (Default: `paths.SPAM_ASSASSIN_PATHS.raw_spam`)
     """
+    if not (external_path and raw_ham_path and raw_spam_path):
+        error_message = "All arguments must be valid pathlib.Path instances (not None)."
+        raise ValueError(error_message)
+
     logger.info("Starting SpamAssassin data organisation...")
     logger.info("Creating directories...")
     raw_ham_path.mkdir(parents=True, exist_ok=True)

--- a/src/email_spam_filter/data/organise/spamassassin/functions.py
+++ b/src/email_spam_filter/data/organise/spamassassin/functions.py
@@ -15,14 +15,14 @@ logger = logging.getLogger(__name__)
 
 
 def organise_spamassassin_data(
-    raw_external_path: pathlib.Path = paths.SPAM_ASSASSIN_PATHS.raw_external,
+    external_path: pathlib.Path = paths.SPAM_ASSASSIN_PATHS.external,
     raw_ham_path: pathlib.Path = paths.SPAM_ASSASSIN_PATHS.raw_ham,
     raw_spam_path: pathlib.Path = paths.SPAM_ASSASSIN_PATHS.raw_spam,
 ) -> None:
     """Reads the SpamAssassin external folders and copies each file into a ham or spam folder.
 
     Args:
-        raw_external_path: Path to the external sourced raw Spam Assassin dataset.
+        external_path: Path to the external sourced raw Spam Assassin dataset.
             (Default: `paths.SPAM_ASSASSIN_PATHS.raw_external`)
         raw_ham_path: Path to the folder where the ham .eml files will be stored.
             (Default: `paths.SPAM_ASSASSIN_PATHS.raw_ham`)
@@ -35,9 +35,9 @@ def organise_spamassassin_data(
     raw_spam_path.mkdir(parents=True, exist_ok=True)
 
     logger.info("Organising data...")
-    if not raw_external_path.is_dir():
+    if not external_path.is_dir():
         error_message = (
-            f"SpamAssassin data not found at {raw_external_path!r}. "
+            f"SpamAssassin data not found at {external_path!r}. "
             "Please verify that the dataset directory exists and contains subfolders "
             "containing either the words 'ham' or 'spam'. You can download the correct data from: https://spamassassin.apache.org/old/publiccorpus/"
         )
@@ -47,7 +47,7 @@ def organise_spamassassin_data(
     ham_uid: int = 0
     spam_uid: int = 0
 
-    for subdir in sorted(raw_external_path.iterdir()):
+    for subdir in sorted(external_path.iterdir()):
         subdir_name = subdir.name.lower()
         if not subdir.is_dir() or not any(tag in subdir_name for tag in ("ham", "spam")):
             error_message = f"Incorrect folder '{subdir.name}' in SpamAssassin external data."

--- a/src/email_spam_filter/data/organise/spamassassin/functions.py
+++ b/src/email_spam_filter/data/organise/spamassassin/functions.py
@@ -1,0 +1,80 @@
+"""Functions for loading and standardising the SpamAssassin dataset."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import typing
+
+from email_spam_filter.common import paths
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+logger = logging.getLogger(__name__)
+
+
+def organise_spamassassin_data(
+    raw_external_path: pathlib.Path = paths.SPAM_ASSASSIN_PATHS.raw_external,
+    raw_ham_path: pathlib.Path = paths.SPAM_ASSASSIN_PATHS.raw_ham,
+    raw_spam_path: pathlib.Path = paths.SPAM_ASSASSIN_PATHS.raw_spam,
+) -> None:
+    """Reads the SpamAssassin external folders and copies each file into a ham or spam folder.
+
+    Args:
+        raw_external_path: Path to the external sourced raw Spam Assassin dataset.
+            (Default: `paths.SPAM_ASSASSIN_PATHS.raw_external`)
+        raw_ham_path: Path to the folder where the ham .eml files will be stored.
+            (Default: `paths.SPAM_ASSASSIN_PATHS.raw_ham`)
+        raw_spam_path: Path to the folder where the spam .eml files will be stored.
+            (Default: `paths.SPAM_ASSASSIN_PATHS.raw_spam`)
+    """
+    logger.info("Starting SpamAssassin data organisation...")
+    logger.info("Creating directories...")
+    raw_ham_path.mkdir(parents=True, exist_ok=True)
+    raw_spam_path.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Organising data...")
+    if not raw_external_path.is_dir():
+        error_message = (
+            f"SpamAssassin data not found at {raw_external_path!r}. "
+            "Please verify that the dataset directory exists and contains subfolders "
+            "containing either the words 'ham' or 'spam'. You can download the correct data from: https://spamassassin.apache.org/old/publiccorpus/"
+        )
+        raise FileNotFoundError(error_message)
+
+    missing_files: list[pathlib.Path] = []
+    ham_uid: int = 0
+    spam_uid: int = 0
+
+    for subdir in sorted(raw_external_path.iterdir()):
+        subdir_name = subdir.name.lower()
+        if not subdir.is_dir() or not any(tag in subdir_name for tag in ("ham", "spam")):
+            error_message = f"Incorrect folder '{subdir.name}' in SpamAssassin external data."
+            raise FileNotFoundError(error_message)
+
+        label = "spam" if "spam" in subdir_name else "ham"
+        for src in sorted(subdir.iterdir()):
+            if not src.is_file():
+                missing_files.append(src)
+                logger.debug("[!] Skipping invalid or non-file entry: %s", src)
+                continue
+            if label == "ham":
+                ham_uid += 1
+                dest = raw_ham_path / f"{ham_uid}_ham.eml"
+            elif label == "spam":
+                spam_uid += 1
+                dest = raw_spam_path / f"{spam_uid}_spam.eml"
+            else:
+                missing_files.append(src)
+                logger.debug("[!] Unrecognised label for data file: %s", src)
+
+            shutil.copy(str(src), str(dest))
+
+    if missing_files:
+        logger.warning(
+            "Skipped %d invalid or missing files. Change logger level to DEBUG to view details.",
+            len(missing_files),
+        )
+
+    logger.info("SpamAssassin data organisation complete.")

--- a/src/email_spam_filter/data/organise/trec/__init__.py
+++ b/src/email_spam_filter/data/organise/trec/__init__.py
@@ -1,0 +1,13 @@
+"""Pre-processing utilities for the TREC Public Spam Corpus.
+
+Modules:
+    functions: Functions for loading and standardising the TREC Public Spam Corpus.
+"""
+
+from __future__ import annotations
+
+__all__ = ("organise_trec_data",)
+
+from email_spam_filter.data.organise.trec.functions import (
+    organise_trec_data,
+)

--- a/src/email_spam_filter/data/organise/trec/functions.py
+++ b/src/email_spam_filter/data/organise/trec/functions.py
@@ -15,14 +15,14 @@ logger = logging.getLogger(__name__)
 
 
 def organise_trec_data(
-    raw_external_path: pathlib.Path = paths.TREC_PATHS.raw_external,
+    external_path: pathlib.Path = paths.TREC_PATHS.external,
     raw_ham_path: pathlib.Path = paths.TREC_PATHS.raw_ham,
     raw_spam_path: pathlib.Path = paths.TREC_PATHS.raw_spam,
 ) -> None:
     """Reads the TREC index and copies each file into a ham or spam folder.
 
     Args:
-        raw_external_path: Path to the external sourced raw TREC dataset.
+        external_path: Path to the external sourced TREC dataset.
             (Default: `paths.TREC_PATHS.raw_external`)
         raw_ham_path: Path to the folder where the ham .eml files will be stored.
             (Default: `paths.TREC_PATHS.raw_ham`)
@@ -35,7 +35,7 @@ def organise_trec_data(
     raw_spam_path.mkdir(parents=True, exist_ok=True)
 
     logger.info("Organising data...")
-    index_path = raw_external_path / "full" / "index"
+    index_path = external_path / "full" / "index"
     if not index_path.is_file():
         error_message = (
             f"Index file not found at {index_path!r}. Please verify that the TREC "
@@ -54,7 +54,7 @@ def organise_trec_data(
             if label not in ("ham", "spam"):
                 error_message = f"Invalid tag {label} in index"
                 raise RuntimeError(error_message)
-            src = (raw_external_path / "full" / rel_path).resolve()
+            src = (external_path / "full" / rel_path).resolve()
             if not src.is_file():
                 missing_files.append(src)
                 logger.debug("[!] Data file missing: %s", src)

--- a/src/email_spam_filter/data/organise/trec/functions.py
+++ b/src/email_spam_filter/data/organise/trec/functions.py
@@ -1,0 +1,79 @@
+"""Functions for loading and standardising the TREC Public Spam Corpus."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import typing
+
+from email_spam_filter.common import paths
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+logger = logging.getLogger(__name__)
+
+
+def organise_trec_data(
+    raw_external_path: pathlib.Path = paths.TREC_PATHS.raw_external,
+    raw_ham_path: pathlib.Path = paths.TREC_PATHS.raw_ham,
+    raw_spam_path: pathlib.Path = paths.TREC_PATHS.raw_spam,
+) -> None:
+    """Reads the TREC index and copies each file into a ham or spam folder.
+
+    Args:
+        raw_external_path: Path to the external sourced raw TREC dataset.
+            (Default: `paths.TREC_PATHS.raw_external`)
+        raw_ham_path: Path to the folder where the ham .eml files will be stored.
+            (Default: `paths.TREC_PATHS.raw_ham`)
+        raw_spam_path: Path to the folder where the spam .eml files will be stored.
+            (Default: `paths.TREC_PATHS.raw_spam`)
+    """
+    logger.info("Starting TREC data organisation...")
+    logger.info("Creating directories...")
+    raw_ham_path.mkdir(parents=True, exist_ok=True)
+    raw_spam_path.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Organising data...")
+    index_path = raw_external_path / "full" / "index"
+    if not index_path.is_file():
+        error_message = (
+            f"Index file not found at {index_path!r}. Please verify that the TREC "
+            "dataset was unzipped correctly, the directory names are accurate, and a 'full' folder "
+            "containing an 'index' file exists. You can download the correct data from: https://plg.uwaterloo.ca/cgi-bin/cgiwrap/gvcormac/foo"
+        )
+        raise FileNotFoundError(error_message)
+
+    missing_files: list[pathlib.Path] = []
+    ham_uid: int = 0
+    spam_uid: int = 0
+
+    with index_path.open() as idx_file:
+        for line in idx_file:
+            label, rel_path = line.strip().split(maxsplit=1)
+            if label not in ("ham", "spam"):
+                error_message = f"Invalid tag {label} in index"
+                raise RuntimeError(error_message)
+            src = (raw_external_path / "full" / rel_path).resolve()
+            if not src.is_file():
+                missing_files.append(src)
+                logger.debug("[!] Data file missing: %s", src)
+                continue
+            if label == "ham":
+                ham_uid += 1
+                dest = raw_ham_path / f"{ham_uid}_ham.eml"
+            elif label == "spam":
+                spam_uid += 1
+                dest = raw_spam_path / f"{spam_uid}_spam.eml"
+            else:
+                missing_files.append(src)
+                logger.debug("[!] Unrecognised label for data file: %s", src)
+            shutil.copy(str(src), str(dest))
+
+    if missing_files:
+        logger.warning(
+            "Skipped %d invalid or missing files. Change logger level to DEBUG to view details.",
+            len(missing_files),
+        )
+
+    logger.info("TREC data organisation complete.")

--- a/src/email_spam_filter/data/organise/trec/functions.py
+++ b/src/email_spam_filter/data/organise/trec/functions.py
@@ -15,9 +15,9 @@ logger = logging.getLogger(__name__)
 
 
 def organise_trec_data(
-    external_path: pathlib.Path = paths.TREC_PATHS.external,
-    raw_ham_path: pathlib.Path = paths.TREC_PATHS.raw_ham,
-    raw_spam_path: pathlib.Path = paths.TREC_PATHS.raw_spam,
+    external_path: pathlib.Path | None = paths.TREC_PATHS.external,
+    raw_ham_path: pathlib.Path | None = paths.TREC_PATHS.raw_ham,
+    raw_spam_path: pathlib.Path | None = paths.TREC_PATHS.raw_spam,
 ) -> None:
     """Reads the TREC index and copies each file into a ham or spam folder.
 
@@ -29,6 +29,10 @@ def organise_trec_data(
         raw_spam_path: Path to the folder where the spam .eml files will be stored.
             (Default: `paths.TREC_PATHS.raw_spam`)
     """
+    if not (external_path and raw_ham_path and raw_spam_path):
+        error_message = "All arguments must be valid pathlib.Path instances (not None)."
+        raise ValueError(error_message)
+
     logger.info("Starting TREC data organisation...")
     logger.info("Creating directories...")
     raw_ham_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Once merged this will close #5

This will include:
- [ ] Creation of `data.organise` submodule
- [ ] Creation of `data.organise.trec` submodule (To organise [TREC Public Corpus data](https://plg.uwaterloo.ca/cgi-bin/cgiwrap/gvcormac/foo))
- [ ] Creation of `data.organise.spamassassin` submodule (To organise [SpamAssassin Public Corpus data](https://spamassassin.apache.org/old/publiccorpus/))
- [ ] Updating file structure and imports
- [ ] Creation of a simple `organise_external_data.py` script
- [ ] Updating `README.md` (To guide user on how to download the raw public corpora)
- [ ] Adding working tests for all new features