### PR TITLE
Add temporary step to github workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,9 @@ jobs:
           cache-environment: true
       - name: Install dependencies
         run: python -m poetry install --with=dev
+      - name: Run setup script (Temporary fix to prevent failed checks in Proof of Concept branch)
+        run: |
+          poetry run setup || echo "Skipping setup: script not defined or failed"
       - name: Lint with Ruff
         run: python -m poetry run ruff check .
       - name: Type check with mypy


### PR DESCRIPTION
This is a quick fix for failing checks encountered in #20. It should always pass with no error, but allows the default `.env` file to be created correctly once the `setup.py` script is added. When #17 is merged, it should change this to a less temporary step.